### PR TITLE
test 724: fix outer/inner members

### DIFF
--- a/grid/data/7-mp-geom/724/data.osm
+++ b/grid/data/7-mp-geom/724/data.osm
@@ -35,8 +35,8 @@
         <tag k="test:id" v="724"/>
     </way>
     <relation id="724900" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
-        <member type="way" ref="724800" role="outer"/>
-        <member type="way" ref="724801" role="inner"/>
+        <member type="way" ref="724801" role="outer"/>
+        <member type="way" ref="724800" role="inner"/>
         <tag k="type" v="multipolygon"/>
         <tag k="test:section" v="mp-geom"/>
         <tag k="test:id" v="724"/>


### PR DESCRIPTION
In test 724, nodes 000,001,010,011 are actually inside way 801, so this one should be the outer ring and way 800 the inner ring.
