### PR TITLE
test 729: fix outer/inner members

### DIFF
--- a/grid/data/7-mp-geom/729/data.osm
+++ b/grid/data/7-mp-geom/729/data.osm
@@ -40,8 +40,8 @@
         <tag k="test:id" v="729"/>
     </way>
     <relation id="729900" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
-        <member type="way" ref="729800" role="outer"/>
-        <member type="way" ref="729801" role="inner"/>
+        <member type="way" ref="729801" role="outer"/>
+        <member type="way" ref="729800" role="inner"/>
         <member type="way" ref="729802" role="outer"/>
         <tag k="type" v="multipolygon"/>
         <tag k="test:section" v="mp-geom"/>


### PR DESCRIPTION
way 801 is actually the innermost ring (inside way 800, which is inside way 802), so it must have the outer role.
