### PR TITLE
Add npm compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('path').resolve(__dirname, 'grid', 'data');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "osm-testdata",
+  "version": "1.0.0",
+  "description": "OpenStreetMap Test Data",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/osmcode/osm-testdata.git"
+  },
+  "keywords": [
+    "OpenStreetMap",
+    "test",
+    "data"
+  ],
+  "author": "Jochen Topf",
+  "license": "PDDL-1.0",
+  "bugs": {
+    "url": "https://github.com/osmcode/osm-testdata/issues"
+  },
+  "homepage": "https://github.com/osmcode/osm-testdata#readme"
+}


### PR DESCRIPTION
Adds package.json and index.js, making the fixtures installable via npm for use in testing node.js scripts.
